### PR TITLE
Add alt output format of slice of predictions

### DIFF
--- a/kmeans.go
+++ b/kmeans.go
@@ -40,16 +40,14 @@ func New() Kmeans {
 	return m
 }
 
-// Partition executes the k-means algorithm on the given dataset and
-// partitions it into k clusters
-func (m Kmeans) Partition(dataset clusters.Observations, k int) (clusters.Clusters, error) {
+func (m Kmeans) partition(dataset clusters.Observations, k int) (clusters.Clusters, []int, error) {
 	if k > len(dataset) {
-		return clusters.Clusters{}, fmt.Errorf("the size of the data set must at least equal k")
+		return clusters.Clusters{}, nil, fmt.Errorf("the size of the data set must at least equal k")
 	}
 
 	cc, err := clusters.New(k, dataset)
 	if err != nil {
-		return cc, err
+		return cc, nil, err
 	}
 
 	points := make([]int, len(dataset))
@@ -105,5 +103,20 @@ func (m Kmeans) Partition(dataset clusters.Observations, k int) (clusters.Cluste
 		}
 	}
 
-	return cc, nil
+	return cc, points, nil
+}
+
+// Partition executes the k-means algorithm on the given dataset and
+// partitions it into k clusters
+func (m Kmeans) Partition(dataset clusters.Observations, k int) (clusters.Clusters, error) {
+	cc, _, err := m.partition(dataset, k)
+	return cc, err
+}
+
+// PartitionPoints executes the k-means algorithm on the given dataset and
+// partitions it into k clusters, returning a slice containing to which cluster
+// each point was assigned to
+func (m Kmeans) PartitionPoints(dataset clusters.Observations, k int) ([]int, error) {
+	_, points, err := m.partition(dataset, k)
+	return points, err
 }

--- a/kmeans_test.go
+++ b/kmeans_test.go
@@ -30,6 +30,10 @@ func TestPartitioningError(t *testing.T) {
 		t.Errorf("Expected error partitioning with empty data set, got nil")
 		return
 	}
+	if _, err := km.PartitionPoints(d, 1); err == nil {
+		t.Errorf("Expected error partitioning with empty data set, got nil")
+		return
+	}
 
 	d = clusters.Observations{
 		clusters.Coordinates{
@@ -41,8 +45,16 @@ func TestPartitioningError(t *testing.T) {
 		t.Errorf("Expected error partitioning with 0 clusters, got nil")
 		return
 	}
+	if _, err := km.PartitionPoints(d, 0); err == nil {
+		t.Errorf("Expected error partitioning with 0 clusters, got nil")
+		return
+	}
 
 	if _, err := km.Partition(d, 2); err == nil {
+		t.Errorf("Expected error partitioning with more clusters than data points, got nil")
+		return
+	}
+	if _, err := km.PartitionPoints(d, 2); err == nil {
 		t.Errorf("Expected error partitioning with more clusters than data points, got nil")
 		return
 	}
@@ -68,6 +80,23 @@ func TestDimensions(t *testing.T) {
 	}
 
 	if len(clusters) != k {
+		t.Errorf("Expected %d clusters, got: %d", k, len(clusters))
+	}
+
+	pclusters, err := km.PartitionPoints(d, k)
+	if err != nil {
+		t.Errorf("Unexpected error partitioning: %v", err)
+		return
+	}
+
+	var m int
+	for _, g := range pclusters {
+		if g > m {
+			m = g
+		}
+	}
+
+	if m != k-1 {
 		t.Errorf("Expected %d clusters, got: %d", k, len(clusters))
 	}
 }


### PR DESCRIPTION
This patch provides an alternative output format. Previously, retrieving
an array of predictions was worst case quadratic time, as each cluster's
observations would have to be compared with the original observations
and then assigned their designated cluster. This commit resolves this
issue by simply returning the already generated internal slice of
predictions from Partition.
`---`

This is a use case that I have. I need performance and to be able to preserve the original observations order, so I'm sending this as a PR. Totally understand if you don't want to merge this, as it doesn't use your muesli/clusters format.

I wasn't sure on the name (`PartitionPoints`), so feel free to change that (or provide suggestions for a v2).