### PR TITLE
Bump go-chart dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,6 @@ require (
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.0.2
 	github.com/muesli/clusters v0.0.0-20180605185049-a07a36e67d36
-	github.com/wcharczuk/go-chart v2.0.1+incompatible
+	github.com/wcharczuk/go-chart v2.0.2-0.20191206192251-962b9abdec2b+incompatible
 	golang.org/x/image v0.0.0-20190501045829-6d32002ffd75 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/muesli/clusters v0.0.0-20180605185049-a07a36e67d36 h1:KMCH+/bbZsAbFgz
 github.com/muesli/clusters v0.0.0-20180605185049-a07a36e67d36/go.mod h1:mw5KDqUj0eLj/6DUNINLVJNoPTFkEuGMHtJsXLviLkY=
 github.com/wcharczuk/go-chart v2.0.1+incompatible h1:0pz39ZAycJFF7ju/1mepnk26RLVLBCWz1STcD3doU0A=
 github.com/wcharczuk/go-chart v2.0.1+incompatible/go.mod h1:PF5tmL4EIx/7Wf+hEkpCqYi5He4u90sw+0+6FhrryuE=
+github.com/wcharczuk/go-chart v2.0.2-0.20191206192251-962b9abdec2b+incompatible h1:ahpaSRefPekV3gcXot2AOgngIV8WYqzvDyFe3i7W24w=
+github.com/wcharczuk/go-chart v2.0.2-0.20191206192251-962b9abdec2b+incompatible/go.mod h1:PF5tmL4EIx/7Wf+hEkpCqYi5He4u90sw+0+6FhrryuE=
 golang.org/x/image v0.0.0-20190501045829-6d32002ffd75 h1:TbGuee8sSq15Iguxu4deQ7+Bqq/d2rsQejGcEtADAMQ=
 golang.org/x/image v0.0.0-20190501045829-6d32002ffd75/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/plotter.go
+++ b/plotter.go
@@ -42,7 +42,7 @@ func (p SimplePlotter) Plot(cc clusters.Clusters, iteration int) error {
 	for i, c := range cc {
 		series = append(series, chart.ContinuousSeries{
 			Style: chart.Style{
-				Show:        true,
+				Hidden:		 false,
 				StrokeWidth: chart.Disabled,
 				DotColor:    colors[i%len(colors)],
 				DotWidth:    8,
@@ -55,7 +55,7 @@ func (p SimplePlotter) Plot(cc clusters.Clusters, iteration int) error {
 	// draw cluster center points
 	series = append(series, chart.ContinuousSeries{
 		Style: chart.Style{
-			Show:        true,
+			Hidden:		 false,
 			StrokeWidth: chart.Disabled,
 			DotColor:    drawing.ColorBlack,
 			DotWidth:    16,
@@ -70,12 +70,12 @@ func (p SimplePlotter) Plot(cc clusters.Clusters, iteration int) error {
 		Series: series,
 		XAxis: chart.XAxis{
 			Style: chart.Style{
-				Show: true,
+				Hidden:	 false,
 			},
 		},
 		YAxis: chart.YAxis{
 			Style: chart.Style{
-				Show: true,
+				Hidden:	 false,
 			},
 		},
 	}

--- a/plotter.go
+++ b/plotter.go
@@ -42,7 +42,6 @@ func (p SimplePlotter) Plot(cc clusters.Clusters, iteration int) error {
 	for i, c := range cc {
 		series = append(series, chart.ContinuousSeries{
 			Style: chart.Style{
-				Hidden:		 false,
 				StrokeWidth: chart.Disabled,
 				DotColor:    colors[i%len(colors)],
 				DotWidth:    8,
@@ -55,7 +54,6 @@ func (p SimplePlotter) Plot(cc clusters.Clusters, iteration int) error {
 	// draw cluster center points
 	series = append(series, chart.ContinuousSeries{
 		Style: chart.Style{
-			Hidden:		 false,
 			StrokeWidth: chart.Disabled,
 			DotColor:    drawing.ColorBlack,
 			DotWidth:    16,
@@ -70,12 +68,10 @@ func (p SimplePlotter) Plot(cc clusters.Clusters, iteration int) error {
 		Series: series,
 		XAxis: chart.XAxis{
 			Style: chart.Style{
-				Hidden:	 false,
 			},
 		},
 		YAxis: chart.YAxis{
 			Style: chart.Style{
-				Hidden:	 false,
 			},
 		},
 	}


### PR DESCRIPTION
Update to the latest go-chart version. So it doesn't crash because of other modules, which use the latest go-chart version.