### PR TITLE
breaking: add seed to NewWithOptions

### DIFF
--- a/examples/colorpalette/main.go
+++ b/examples/colorpalette/main.go
@@ -69,7 +69,7 @@ func main() {
 	buffer.Write([]byte(header))
 
 	// Enable graph generation (.png files) for each iteration
-	km, _ := kmeans.NewWithOptions(0.01, plotter.SimplePlotter{})
+	km, _ := kmeans.NewWithOptions(0.01, plotter.SimplePlotter{}, 0)
 
 	// Partition the color space into 16 clusters (palette colors)
 	clusters, _ := km.Partition(d, 16)

--- a/kmeans_test.go
+++ b/kmeans_test.go
@@ -12,12 +12,12 @@ const (
 )
 
 func TestNewErrors(t *testing.T) {
-	_, err := NewWithOptions(0.00, nil)
+	_, err := NewWithOptions(0.00, nil, 0)
 	if err == nil {
 		t.Errorf("Expected invalid options to return an error, got nil")
 	}
 
-	_, err = NewWithOptions(1.00, nil)
+	_, err = NewWithOptions(1.00, nil, 0)
 	if err == nil {
 		t.Errorf("Expected invalid options to return an error, got nil")
 	}


### PR DESCRIPTION
hello @muesli, I tried many approaches but did not see an obvious way to keep backwards compatibility, so I am proposing this breaking change. I am open to other approaches.

I was a bit torn on this one, because, although there is a constructor, the seed of the default PRNG is set each time that Partition is called (via clusters.new), so I wanted a way to keep the existing semantics. I came out with the idea of passing the seed to the NewWithOptions ctor and to use the zero value to mean default behavior.

If a client explicitly sets the seed, then each time it calls Partition() on a given Kmean struct, the PRG will be reset to that seed.

I have to say I am not completely convinced. Opinions?

Together with https://github.com/muesli/clusters/pull/1, closes #19.